### PR TITLE
Fix build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ version := "1.0"
 scalaVersion := "2.11.6"
 
 libraryDependencies ++= Seq("org.specs2" %% "specs2-core" % "3.5" % "test")
+
 libraryDependencies += "org.scalaz" %% "scalaz-core" % "7.1.2"
 
 resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"


### PR DESCRIPTION
Fix OpenBidder\build.sbt:8: error: eof expected but ';' found. libraryDependencies += "org.scalaz" %% "scalaz-core" % "7.1.2" [error] Error parsing expression. Ensure that settings are separated by blank lines.